### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ CF = Collaborative Filtering, SSL = Self-Supervised Learning
 
      ACL 2025, [[PDF]](https://arxiv.org/pdf/2508.05657), [[Code]](https://github.com/xu1110/FNSCRS)
 
+78. **Beyond Random Augmentations: Pretraining with Hard Views** (CL + DA)
+
+     ICLR 2025, [[PDF]](https://arxiv.org/abs/2310.03940), [[Code]](https://github.com/automl/hvp)
+
 
 ## Graph Models with CL
 


### PR DESCRIPTION
added the SSL DA paper "Beyond Random Augmentations: Pretraining with Hard Views" into category "only data augmentation"